### PR TITLE
Added xbutil2 fix for edge. Which fix the CR-1094072 CR-1094073

### DIFF
--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -45,7 +45,7 @@ static boost::property_tree::ptree
 mac_addresses(const xrt_core::device * dev)
 {
   boost::property_tree::ptree ptree;
-  uint64_t mac_contiguous_num;
+  uint64_t mac_contiguous_num = 0;
   std::string mac_addr_first;
   try {
     mac_contiguous_num = xrt_core::device_query<qr::mac_contiguous_num>(dev);

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -682,6 +682,9 @@ XBUtilities::check_p2p_config(const xrt_core::device* _dev, std::string &msg)
     msg = "P2P config failed. P2P is not available";
     return static_cast<int>(p2p_config::not_supported);
   }
+  catch (const xrt_core::query::no_such_key&) {
+    return static_cast<int>(p2p_config::not_supported);
+  }
 
   int64_t bar = -1;
   int64_t rbar = -1;


### PR DESCRIPTION
After this change the edge xbutil command looks as follows:
**./xbutil2 examine -r platform**
-------------------------------------------------
1/1 [0000:00:00.0] : xilinx_vck190_base_202110_1
-------------------------------------------------
Platform
  XSA Name               : xilinx_vck190_base_202110_1 
  FPGA Name              : N/A 
  JTAG ID Code           : N/A 
  DDR Size                  : 4294967296 Bytes
  DDR Count              : 1 
  Mig Calibrated         : N/A 
  P2P Status                : not supported 



**./xbutil2 examine -r compute-units**
Compute Units
  PL Compute Units
    Index   Name                          Base_Address    Usage   Status  
    0       vadd:vadd_1                   0xa4050000      1       (START) 

  PS Compute Units
    Index   Name                          Base_Address    Usage   Status  

